### PR TITLE
Added paypal flag to turn off feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,6 +120,8 @@ global.ERROR_MYSQL_SYSTEM_ERROR_ON_RPC = 132;
 global.ERROR_ON_FILE_UPLOAD = 133;
 global.ERROR_FEATURE_UNAVAILABLE_OVERNIGHT = 134;
 
+global.PAYPAL_FLAG = 1; // paypal on by default
+
 const { auth } = require('express-openid-connect');
 
 const config = {

--- a/routes/assassin.js
+++ b/routes/assassin.js
@@ -174,6 +174,7 @@ router.get('/', function(req, res, next) {
                                   // route to home page passing Player info and teammate info
                                   res.render('home', {
                                   adminPlayerCode: CREDENTIALS.ADMIN_PLAYER_CODE,
+                                  paypalFlag: PAYPAL_FLAG,
                                   gameStatus: rows[0][0].gameStatus,
                                   playerCode: rows[0][0].playerCode,
                                   playerName: rows[0][0].playerName,
@@ -221,6 +222,7 @@ router.get('/', function(req, res, next) {
                       {
                           res.render('home', {
                           adminPlayerCode: CREDENTIALS.ADMIN_PLAYER_CODE,
+                          paypalFlag: PAYPAL_FLAG,
                           gameStatus: rows[0][0].gameStatus,
                           playerCode: rows[0][0].playerCode,
                           playerName: rows[0][0].playerName,
@@ -2583,7 +2585,7 @@ router.post('/viewRules', function(req, res, next)
     }
 
     // No stored procedure needed, just display rules page
-    res.render('rules');
+    res.render('rules', {paypalFlag: PAYPAL_FLAG}); // zzzz
 
 });  // end router - viewRules
 

--- a/views/captainFeatures.ejs
+++ b/views/captainFeatures.ejs
@@ -123,11 +123,14 @@
                         case "Registered":
                         case "Pics Approved":
 
+                            if (paypalFlag == 1)
+                            {
                             %>
                                 <hr>
                                 <%- include('paypal'); %>
-                                <div style="height: 16px;"></div>
+                                <div style="height: 8px;"></div>
                             <%
+                            }
                                 break;
 
         							default:

--- a/views/rules.ejs
+++ b/views/rules.ejs
@@ -26,14 +26,23 @@
 
 					<div class="rules-page">
 
-            Assassin is a game of stealth, patience, and trickery.  It's also a great way to meet other PorcFest attendees.  The object of the game is to assassinate as many targets as possible while avoiding being assassinated yourself.  This year’s big change is the introduction of teams (1, 2, or 3 players).  You get the team name, player name, and picture of your target.  If your team assassinates your target, you get a $5 bounty and a new target.  Someone else always has your team as their target.  If they assassinate your team, you’re out of the game but can buy back in through the site if you have accrued bounties.
+            Assassin is a campground game of stealth, patience, and trickery.  It's also a great way to meet other PorcFest attendees.  The object of the game is to assassinate as many targets as possible with your squirt gun while avoiding being assassinated yourself.  This year’s big change is the introduction of teams (1, 2, or 3 players).  You get the team name, player name, and picture of your target.  If your team assassinates your target, you get a $5 bounty and a new target.  Someone else always has your team as their target.  If they assassinate your team, you’re out of the game but can buy back in through the site if you have accrued bounties.
 						<div style="height: 10px;"></div>
 						Detailed Rules:
             <ul>
               <li>The game begins Wednesday at 9 AM and ends Saturday at 9:00 pm.</li>
 							<li>No assassinations are valid overnight between 9 PM and 9 AM.</li>
 							<li>Contact the Admin through the website after reading through these rules if you have any questions.</li>
-							<li>Players can register, upload their photo, and pay for their Team ($10) at any time without Admin assistance or you can register in person with the Admin at Porcfest.  Team fees will be refunded if the team doesn’t play.</li>
+
+							<% if (paypalFlag == 1)
+								{ %>
+									<li>Players can register, upload their photo, and pay for their Team ($10) at any time without Admin assistance or you can register in person with the Admin at Porcfest.  Team fees will be refunded if the team doesn’t play.</li>
+						<% 	} else
+								{ %>
+									<li>Players can register and upload their photo at any time without Admin assistance or you can register in person with the Admin at Porcfest.</li>
+						<% 	} %>
+
+							<li>Players can bring their own squirt guns or purchase them from the Admin for $1.</li>
 							<li>A new feature this year is the use of your email address and a password to login to the website.</li>
 							<li>Another new feature is SMS text alerts for major game events.  It is highly recommended to include your phone number when registering to receive alerts including the moment you go Live in the game.</li>
 							<li>Teams can be 1, 2, or 3 players.  Only 1 player is “Live” at a given time.  The Live player is the only one that can assassinate the target or be assassinated.  The other players on the team are on the “Bench” but can still assist the Live player.</li>


### PR DESCRIPTION
Added a global flag in app.js to turn on and off paypal just in case we get cancelled just before porcfest.  Wording update to rules page depending on paypal flag, also paypal widgets on/off.