### PR TITLE
Paypal updates - only see it when no bounties - allow paypal for rebuy

### DIFF
--- a/views/captainFeatures.ejs
+++ b/views/captainFeatures.ejs
@@ -104,8 +104,19 @@
                       case "Inactive":
                           %>
                               <hr>
-                              <%- include('paypal'); %>
-                              <div style="height: 16px;"></div>
+
+                          <% if ((paypalFlag == 1) && (teamBountiesOwed == 0))
+                              {
+                          %>
+                                  Pay again through Paypal and you will be credited with a bounty and can then Rebuy.
+                                  <div style="height: 14px;"></div>
+
+                                  <%- include('paypal'); %>
+                                  <div style="height: 6px;"></div>
+
+                          <% } %>
+
+                              <div style="height: 6px;"></div>
                           <%
                             if (teamBountiesOwed >= 1)
                             {
@@ -128,7 +139,7 @@
                             %>
                                 <hr>
                                 <%- include('paypal'); %>
-                                <div style="height: 8px;"></div>
+                                <div style="height: 6px;"></div>
                             <%
                             }
                                 break;


### PR DESCRIPTION
2 paypal updates - 1) Only see paypal when you have no bounties.  If you have bounties owed, you'll see the Rebuy button only.  2) When you're out of bounties, you can now pay again, need to update this further because its now pointing at $10 instead of a $5 rebuy.  That will be next update.