### PR TITLE
admin text new reg bug fix

### DIFF
--- a/routes/assassin.js
+++ b/routes/assassin.js
@@ -407,7 +407,15 @@ router.post('/newAssassin', function(req, res, next)
             // Check return code
             if (rows[0][0].phone == CALL_SUCCESS)
             {
-                adminPhone = rows[0][0].adminPhone;
+
+                if ((req.body.playerTeamName == null) || (req.body.playerTeamName == ""))
+                {
+                  adminPhone = rows[0][0].adminPhone;
+                }
+                else
+                {
+                  adminPhone = rows[1][0].adminPhone;
+                }
 
                 // Use mv() to place file on the server
                 playerPhotoFile.mv(uploadPath, function (err)


### PR DESCRIPTION
Admin text was not working for scenario where person registers with team.  For some reason, create team rpc is adding more data to the call to create a new player with team.  I now differentiate in the node layer.